### PR TITLE
Evitar que un trabajo se aplique en un pull request

### DIFF
--- a/.github/workflows/gha-pullrequest-verify-event.yml
+++ b/.github/workflows/gha-pullrequest-verify-event.yml
@@ -1,0 +1,24 @@
+name: Evitar un trabajo en un pull request
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        if: ${{ github.event_name=='push' }}
+        run: npm run lint


### PR DESCRIPTION
Se aplica un if usando el contexto global que permite github obtener el evento y asi evitar que un trabajo se aplique en un pull request